### PR TITLE
docs: fix Python references to Ruby in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Background knowledge the agent should always have access to.
 
 - **Name**: John
 - **Timezone**: UTC+1
-- **Preferences**: Prefers Python over JavaScript
+- **Preferences**: Prefers Ruby over JavaScript
 
 ## Project Context
 

--- a/lib/pocketrb/skills/builtin/tmux/SKILL.md
+++ b/lib/pocketrb/skills/builtin/tmux/SKILL.md
@@ -40,7 +40,7 @@ SOCKET="$SOCKET_DIR/pocketrb.sock"
 tmux -S "$SOCKET" new-session -d -s mysession
 
 # Create session with initial command
-tmux -S "$SOCKET" new-session -d -s mysession "python3"
+tmux -S "$SOCKET" new-session -d -s mysession "irb"
 
 # List sessions
 tmux -S "$SOCKET" list-sessions
@@ -86,7 +86,7 @@ tmux -S "$SOCKET" capture-pane -p -t mysession > output.txt
 
 ```bash
 # Send command
-tmux -S "$SOCKET" send-keys -t mysession "python3 script.py" Enter
+tmux -S "$SOCKET" send-keys -t mysession "ruby script.rb" Enter
 
 # Wait for completion (simple approach)
 sleep 2
@@ -95,19 +95,19 @@ sleep 2
 tmux -S "$SOCKET" capture-pane -p -J -t mysession -S -50
 ```
 
-### Interactive Python/REPL Session
+### Interactive Ruby/IRB Session
 
 ```bash
-# Start Python session
-tmux -S "$SOCKET" new-session -d -s python "python3"
+# Start IRB session
+tmux -S "$SOCKET" new-session -d -s ruby "irb"
 
-# Send Python commands
-tmux -S "$SOCKET" send-keys -t python "import os" Enter
-tmux -S "$SOCKET" send-keys -t python "print(os.getcwd())" Enter
+# Send Ruby commands
+tmux -S "$SOCKET" send-keys -t ruby "require 'pathname'" Enter
+tmux -S "$SOCKET" send-keys -t ruby "puts Pathname.pwd" Enter
 
 # Get output
 sleep 1
-tmux -S "$SOCKET" capture-pane -p -t python
+tmux -S "$SOCKET" capture-pane -p -t ruby
 ```
 
 ### SSH Session


### PR DESCRIPTION
## Summary

This PR fixes incorrect Python references in the documentation, replacing them with appropriate Ruby equivalents to align with the Ruby-based nature of the pocketrb project.

## Changes

- **README.md**: Updated user preference example from "Prefers Python over JavaScript" to "Prefers Ruby over JavaScript"
- **tmux SKILL.md**: 
  - Converted Python/python3 examples to Ruby/IRB
  - Updated section heading from "Interactive Python/REPL Session" to "Interactive Ruby/IRB Session"
  - Replaced Python code examples with Ruby equivalents:
    - `import os` → `require 'pathname'`
    - `print(os.getcwd())` → `puts Pathname.pwd`
  - Changed session names and commands throughout

## Test Plan

- [x] Documentation examples are now consistent with Ruby
- [x] All tmux examples use Ruby/IRB instead of Python
- [x] Code examples use proper Ruby idioms

## Notes

The `background_job_manager.rb` file was intentionally left unchanged as it correctly includes pattern matching for both Python and Ruby scripts, which is appropriate for detecting various types of long-running jobs.