### PR TITLE
feat: add spinner to chat CLI for better UX

### DIFF
--- a/lib/pocketrb/cli/chat.rb
+++ b/lib/pocketrb/cli/chat.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "tty-spinner"
+
 module Pocketrb
   class CLI
     # Chat command - interactive chat mode
@@ -53,7 +55,12 @@ module Pocketrb
               content: input
             )
 
+            spinner = TTY::Spinner.new("[:spinner] Thinking...", format: :dots)
+            spinner.auto_spin
+
             response = agent_loop.process_message(msg)
+
+            spinner.stop
             puts "\n#{response.content}" if response
           end
         end

--- a/pocketrb.gemspec
+++ b/pocketrb.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thor", "~> 1.3"
   spec.add_dependency "tty-markdown", "~> 0.7"
   spec.add_dependency "tty-prompt", "~> 0.23"
+  spec.add_dependency "tty-spinner", "~> 0.9"
   spec.add_dependency "yaml", "~> 0.3"
   spec.add_dependency "zeitwerk", "~> 2.6"
 


### PR DESCRIPTION
Addresses feedback from #2

## Problem

User reported lack of visual feedback while waiting for LLM response:
> "The only think I did not like about this first prompt attempt was that there was no user feedback letting me know that the prompt had been accepted and passed on to the LLM. A little spinner would have been nice here."

## Solution

Added animated spinner using `tty-spinner` that displays while the agent processes the user's message.

## Changes

- Add `tty-spinner` dependency (~0.9)
- Display animated dots spinner with "Thinking..." message
- Spinner starts after user enters message
- Spinner stops when response is ready

## Demo

```
> Tell me about Ruby

[⠋] Thinking...
```

The spinner animates automatically in the terminal, providing clear visual feedback that the system is processing.

## Testing

- ✅ All CLI tests pass
- ✅ Rubocop clean
- ✅ Manual testing confirms spinner displays correctly