### PR TITLE
fix: correct rubygems/release-gem SHA to v1.1.2

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -33,4 +33,4 @@ jobs:
         run: |
           bundle install --jobs 4 --retry 3
 
-      - uses: rubygems/release-gem@dac86d0d2ec88bea08b5d9041e5e8115851b4a9c # v1.11.0
+      - uses: rubygems/release-gem@1c162a739e8b4cb21a676e97b087e8268d8fc40b # v1.1.2


### PR DESCRIPTION
Fixes Renovate warning about unable to determine digest for rubygems/release-gem.

## Problem

Renovate reported:
> Could not determine new digest for update (github-tags package rubygems/release-gem)

## Root Cause

The SHA used was for a non-existent version v1.11.0. The actual latest version is v1.1.2.

## Solution

Updated to correct SHA for v1.1.2: `1c162a739e8b4cb21a676e97b087e8268d8fc40b`

This resolves the Renovate warning and allows proper automated updates.