### PR TITLE
feat(compaction): rolling summaries, pressure thresholds, background compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-03-30
+
+### Added
+
+- Rolling summaries in context compaction — prior summary is preserved and incorporated into new summaries across compaction cycles, preventing progressive context loss
+- Pressure-based compaction thresholds — compaction triggers when estimated tokens exceed a configurable percentage of the model's context window (`context_pressure`, default 70%)
+- Background (non-blocking) compaction via `schedule_compaction` with mutex-based thread safety and `wait_for_compaction` for clean shutdown
+- Compaction callbacks (`on_compact`) — fires after successful compaction with summary text and compacted message count
+- Separate compaction model configuration (`compaction_model` config key, `POCKETRB_COMPACTION_MODEL` env var) to use a cheaper/faster model for summaries
+- `context_pressure` configuration (`compaction_pressure` config key, `POCKETRB_COMPACTION_PRESSURE` env var)
+- `Providers::Base#context_window` method (default 200K); `Providers::Anthropic` overrides using MODELS hash
+
 ## [0.1.0] - 2026-02-04
 
 ### Added

--- a/lib/pocketrb/agent/compaction.rb
+++ b/lib/pocketrb/agent/compaction.rb
@@ -8,6 +8,7 @@ module Pocketrb
       DEFAULT_MESSAGE_THRESHOLD = 40      # Compact when exceeding this many messages
       DEFAULT_TOKEN_THRESHOLD = 50_000    # Compact when exceeding this many estimated tokens
       DEFAULT_KEEP_RECENT = 15            # Keep this many recent messages uncompacted
+      DEFAULT_CONTEXT_PRESSURE = 0.7      # Compact when estimated tokens exceed this fraction of context window
       CHARS_PER_TOKEN = 4                 # Rough estimate for token counting
 
       COMPACTION_PROMPT = <<~PROMPT
@@ -17,10 +18,13 @@ module Pocketrb
         - Current task/goal if any
         - Any pending items or context needed for continuation
 
+        If a prior conversation summary is provided, incorporate its key points into your new summary
+        so that important context is preserved across compaction cycles.
+
         Keep the summary under 500 words. Focus on information the assistant needs to continue effectively.
       PROMPT
 
-      attr_reader :provider, :model
+      attr_reader :provider, :model, :context_window, :context_pressure, :on_compact
       attr_accessor :message_threshold, :token_threshold, :keep_recent
 
       # Initialize a new compaction instance
@@ -29,12 +33,29 @@ module Pocketrb
       # @param message_threshold [Integer, nil] Maximum messages before compaction (defaults to DEFAULT_MESSAGE_THRESHOLD)
       # @param token_threshold [Integer, nil] Maximum estimated tokens before compaction (defaults to DEFAULT_TOKEN_THRESHOLD)
       # @param keep_recent [Integer, nil] Number of recent messages to keep uncompacted (defaults to DEFAULT_KEEP_RECENT)
-      def initialize(provider:, model: nil, message_threshold: nil, token_threshold: nil, keep_recent: nil)
+      # @param context_window [Integer, nil] Model context window size in tokens (defaults to provider value)
+      # @param context_pressure [Float, nil] Fraction of context window that triggers compaction (defaults to DEFAULT_CONTEXT_PRESSURE)
+      # @param on_compact [Proc, nil] Callback called after compaction with (summary, compacted_count)
+      def initialize(
+        provider:,
+        model: nil,
+        message_threshold: nil,
+        token_threshold: nil,
+        keep_recent: nil,
+        context_window: nil,
+        context_pressure: nil,
+        on_compact: nil
+      )
         @provider = provider
         @model = model || provider.default_model
         @message_threshold = message_threshold || DEFAULT_MESSAGE_THRESHOLD
         @token_threshold = token_threshold || DEFAULT_TOKEN_THRESHOLD
         @keep_recent = keep_recent || DEFAULT_KEEP_RECENT
+        @context_window = context_window || provider.context_window(model: @model)
+        @context_pressure = context_pressure || DEFAULT_CONTEXT_PRESSURE
+        @on_compact = on_compact
+        @compact_mutex = Mutex.new
+        @compacting = false
       end
 
       # Check if compaction is needed for messages
@@ -43,7 +64,12 @@ module Pocketrb
       def needs_compaction?(messages)
         return false if messages.size <= @keep_recent
 
-        messages.size > @message_threshold || estimate_tokens(messages) > @token_threshold
+        return true if messages.size > @message_threshold
+        return true if estimate_tokens(messages) > @token_threshold
+
+        # Pressure-based: trigger when estimated tokens exceed configured fraction of context window
+        estimated = estimate_tokens(messages)
+        estimated > @context_window * @context_pressure
       end
 
       # Compact messages by summarizing older ones
@@ -63,38 +89,74 @@ module Pocketrb
         to_summarize = messages[0...split_point]
         to_keep = messages[split_point..]
 
+        # Extract prior summary for rolling context preservation
+        prior_summary = extract_prior_summary(to_summarize)
+
         Pocketrb.logger.info("Compacting #{to_summarize.size} messages into summary")
 
-        # Generate summary
-        summary = generate_summary(to_summarize)
+        # Generate summary (incorporating prior summary if present)
+        summary = generate_summary(to_summarize, prior_summary: prior_summary)
+        compacted_count = to_summarize.size
 
         # Build compacted message list
         compacted = []
         compacted << build_summary_message(summary)
         compacted.concat(to_keep)
 
+        @on_compact&.call(summary, compacted_count)
+
         compacted
       end
 
-      # Compact a session's messages in place
+      # Compact a session's messages in place (synchronous)
       # @param session [Session::Session] Session object containing messages to be compacted
       # @return [Boolean] Whether compaction occurred
       def compact_session!(session)
+        @compact_mutex.synchronize do
+          perform_session_compaction(session)
+        end
+      end
+
+      # Schedule asynchronous compaction in a background thread
+      # @param session [Session::Session] Session object containing messages to be compacted
+      # @return [Thread, nil] Background thread or nil if compaction not needed or already running
+      def schedule_compaction(session)
+        return nil if @compacting
+
         messages = session.messages.dup
-        return false unless needs_compaction?(messages)
+        return nil unless needs_compaction?(messages)
 
-        # Filter out system messages for compaction
-        user_assistant_messages = messages.reject { |m| m.role == Providers::Role::SYSTEM }
-        return false if user_assistant_messages.size <= @keep_recent
+        @compacting = true
 
-        compacted = compact(user_assistant_messages)
+        @compact_thread = Thread.new do
+          @compact_mutex.synchronize do
+            perform_session_compaction(session)
+          ensure
+            @compacting = false
+          end
+        end
 
-        # Update session
-        session.messages.clear
-        compacted.each { |m| session.messages << m }
+        @compact_thread
+      end
 
-        Pocketrb.logger.info("Session compacted: #{messages.size} -> #{compacted.size} messages")
-        true
+      # Whether background compaction is currently running
+      # @return [Boolean]
+      def compacting?
+        @compacting
+      end
+
+      # Wait for any in-progress background compaction to finish
+      # @param timeout [Integer, nil] Maximum seconds to wait (nil = wait forever)
+      # @return [Boolean] true if compaction finished, false if timed out
+      def wait_for_compaction(timeout: nil)
+        return true unless @compact_thread&.alive?
+
+        if timeout
+          @compact_thread.join(timeout) ? true : false
+        else
+          @compact_thread.join
+          true
+        end
       end
 
       # Estimate token count for messages
@@ -123,6 +185,27 @@ module Pocketrb
       end
 
       private
+
+      # Perform the actual session compaction (must be called under mutex)
+      # @param session [Session::Session] Session to compact
+      # @return [Boolean] Whether compaction occurred
+      def perform_session_compaction(session)
+        messages = session.messages.dup
+        return false unless needs_compaction?(messages)
+
+        # Filter out system messages for compaction
+        user_assistant_messages = messages.reject { |m| m.role == Providers::Role::SYSTEM }
+        return false if user_assistant_messages.size <= @keep_recent
+
+        compacted = compact(user_assistant_messages)
+
+        # Update session
+        session.messages.clear
+        compacted.each { |m| session.messages << m }
+
+        Pocketrb.logger.info("Session compacted: #{messages.size} -> #{compacted.size} messages")
+        true
+      end
 
       # Adjust split point to keep tool_use/tool_result pairs together
       # If a tool_result is in the kept messages, ensure its corresponding
@@ -169,13 +252,35 @@ module Pocketrb
         end
       end
 
-      def generate_summary(messages)
+      # Extract prior summary text from messages if the first message is a summary
+      # @param messages [Array<Message>] Messages to check
+      # @return [String, nil] Prior summary text or nil
+      def extract_prior_summary(messages)
+        return nil if messages.empty?
+
+        first = messages[0]
+        content = first.content.to_s
+
+        return nil unless content.include?("[Previous conversation summary]")
+
+        # Extract the summary text between markers
+        match = content.match(/\[Previous conversation summary\]\n(.*?)\n\[End of summary/m)
+        match ? match[1] : nil
+      end
+
+      def generate_summary(messages, prior_summary: nil)
         # Format messages for summarization
         formatted = format_for_summary(messages)
 
+        user_content = "Conversation history to summarize:\n\n#{formatted}"
+
+        if prior_summary
+          user_content = "Prior summary from earlier conversation:\n#{prior_summary}\n\n#{user_content}"
+        end
+
         summary_request = [
           Providers::Message.system(COMPACTION_PROMPT),
-          Providers::Message.user("Conversation history to summarize:\n\n#{formatted}")
+          Providers::Message.user(user_content)
         ]
 
         response = @provider.chat(

--- a/lib/pocketrb/agent/compaction.rb
+++ b/lib/pocketrb/agent/compaction.rb
@@ -52,7 +52,9 @@ module Pocketrb
         @token_threshold = token_threshold || DEFAULT_TOKEN_THRESHOLD
         @keep_recent = keep_recent || DEFAULT_KEEP_RECENT
         @context_window = context_window || provider.context_window(model: @model)
+        validate_context_window!(@context_window)
         @context_pressure = context_pressure || DEFAULT_CONTEXT_PRESSURE
+        validate_context_pressure!(@context_pressure)
         @on_compact = on_compact
         @compact_mutex = Mutex.new
         @compacting = false
@@ -63,12 +65,12 @@ module Pocketrb
       # @return [Boolean]
       def needs_compaction?(messages)
         return false if messages.size <= @keep_recent
-
         return true if messages.size > @message_threshold
-        return true if estimate_tokens(messages) > @token_threshold
+
+        estimated = estimate_tokens(messages)
+        return true if estimated > @token_threshold
 
         # Pressure-based: trigger when estimated tokens exceed configured fraction of context window
-        estimated = estimate_tokens(messages)
         estimated > @context_window * @context_pressure
       end
 
@@ -91,6 +93,9 @@ module Pocketrb
 
         # Extract prior summary for rolling context preservation
         prior_summary = extract_prior_summary(to_summarize)
+
+        # Exclude the prior summary message from to_summarize to avoid duplication
+        to_summarize = to_summarize[1..] if prior_summary && !to_summarize.empty?
 
         Pocketrb.logger.info("Compacting #{to_summarize.size} messages into summary")
 
@@ -121,22 +126,25 @@ module Pocketrb
       # @param session [Session::Session] Session object containing messages to be compacted
       # @return [Thread, nil] Background thread or nil if compaction not needed or already running
       def schedule_compaction(session)
-        return nil if @compacting
+        # Guard check-and-set under mutex to prevent concurrent scheduling
+        thread = @compact_mutex.synchronize do
+          return nil if @compacting
 
-        messages = session.messages.dup
-        return nil unless needs_compaction?(messages)
+          messages = session.messages.dup
+          return nil unless needs_compaction?(messages)
 
-        @compacting = true
+          @compacting = true
 
-        @compact_thread = Thread.new do
-          @compact_mutex.synchronize do
-            perform_session_compaction(session)
-          ensure
-            @compacting = false
+          Thread.new do
+            @compact_mutex.synchronize do
+              perform_session_compaction(session)
+            ensure
+              @compacting = false
+            end
           end
         end
 
-        @compact_thread
+        @compact_thread = thread
       end
 
       # Whether background compaction is currently running
@@ -186,22 +194,39 @@ module Pocketrb
 
       private
 
-      # Perform the actual session compaction (must be called under mutex)
+      def validate_context_window!(value)
+        return if value.is_a?(Numeric) && value.positive?
+
+        raise ArgumentError, "context_window must be a positive number (got #{value.inspect})"
+      end
+
+      def validate_context_pressure!(value)
+        return if value.is_a?(Numeric) && value >= 0.0 && value <= 1.0
+
+        raise ArgumentError, "context_pressure must be between 0.0 and 1.0 (got #{value.inspect})"
+      end
+
+      # Perform the actual session compaction (must be called under compaction mutex)
       # @param session [Session::Session] Session to compact
       # @return [Boolean] Whether compaction occurred
       def perform_session_compaction(session)
-        messages = session.messages.dup
-        return false unless needs_compaction?(messages)
+        # Snapshot messages under session lock to avoid races with add_message
+        messages, user_assistant_messages = session.with_lock do
+          msgs = session.messages.dup
+          ua = msgs.reject { |m| m.role == Providers::Role::SYSTEM }
+          [msgs, ua]
+        end
 
-        # Filter out system messages for compaction
-        user_assistant_messages = messages.reject { |m| m.role == Providers::Role::SYSTEM }
+        return false unless needs_compaction?(messages)
         return false if user_assistant_messages.size <= @keep_recent
 
         compacted = compact(user_assistant_messages)
 
-        # Update session
-        session.messages.clear
-        compacted.each { |m| session.messages << m }
+        # Replace session messages under session lock
+        session.with_lock do
+          session.messages.clear
+          compacted.each { |m| session.messages << m }
+        end
 
         Pocketrb.logger.info("Session compacted: #{messages.size} -> #{compacted.size} messages")
         true
@@ -261,7 +286,10 @@ module Pocketrb
         first = messages[0]
         content = first.content.to_s
 
-        return nil unless content.include?("[Previous conversation summary]")
+        # Strict detection: must start with the marker and contain the end marker
+        start_marker = "[Previous conversation summary]"
+        end_marker = "[End of summary"
+        return nil unless content.start_with?(start_marker) && content.include?(end_marker)
 
         # Extract the summary text between markers
         match = content.match(/\[Previous conversation summary\]\n(.*?)\n\[End of summary/m)

--- a/lib/pocketrb/agent/loop.rb
+++ b/lib/pocketrb/agent/loop.rb
@@ -21,6 +21,8 @@ module Pocketrb
       # @param mcp_endpoint [String, nil] MCP server endpoint URL (currently unused)
       # @param enable_compaction [Boolean] Whether to enable context compaction
       # @param compaction_threshold [Integer, nil] Message count threshold for compaction
+      # @param compaction_model [String, nil] Model to use for compaction summaries (defaults to main model)
+      # @param compaction_pressure [Float, nil] Context pressure threshold for compaction (0.0-1.0)
       def initialize(
         bus:,
         provider:,
@@ -31,7 +33,9 @@ module Pocketrb
         system_prompt: nil,
         mcp_endpoint: nil,
         enable_compaction: true,
-        compaction_threshold: nil
+        compaction_threshold: nil,
+        compaction_model: nil,
+        compaction_pressure: nil
       )
         @bus = bus
         @provider = provider
@@ -64,8 +68,10 @@ module Pocketrb
         @compaction = if enable_compaction
                         Compaction.new(
                           provider: @provider,
-                          model: @model,
-                          message_threshold: compaction_threshold
+                          model: compaction_model || @model,
+                          message_threshold: compaction_threshold,
+                          context_window: @provider.context_window(model: @model),
+                          context_pressure: compaction_pressure
                         )
                       end
 
@@ -94,6 +100,7 @@ module Pocketrb
       # Stop the agent loop
       def stop
         @running = false
+        @compaction&.wait_for_compaction(timeout: 10)
         Pocketrb.logger.info("Agent loop stopping")
       end
 
@@ -114,7 +121,9 @@ module Pocketrb
 
         # Compact session history if needed (before building messages)
         if @compaction&.needs_compaction?(session.messages)
-          @compaction.compact_session!(session)
+          @compaction.schedule_compaction(session)
+          # Wait briefly for compaction to finish so we use compacted context
+          @compaction.wait_for_compaction(timeout: 30)
           @sessions.save(session)
         end
 

--- a/lib/pocketrb/agent/loop.rb
+++ b/lib/pocketrb/agent/loop.rb
@@ -122,8 +122,13 @@ module Pocketrb
         # Compact session history if needed (before building messages)
         if @compaction&.needs_compaction?(session.messages)
           @compaction.schedule_compaction(session)
-          # Wait briefly for compaction to finish so we use compacted context
-          @compaction.wait_for_compaction(timeout: 30)
+
+          # Wait for compaction to finish; fall back to synchronous if timeout
+          unless @compaction.wait_for_compaction(timeout: 30)
+            Pocketrb.logger.warn("Background compaction timed out, falling back to synchronous")
+            @compaction.compact_session!(session)
+          end
+
           @sessions.save(session)
         end
 

--- a/lib/pocketrb/config.rb
+++ b/lib/pocketrb/config.rb
@@ -14,6 +14,8 @@ module Pocketrb
     DEFAULTS = {
       provider: "anthropic",
       model: "claude-sonnet-4-20250514",
+      compaction_model: nil,
+      compaction_pressure: nil,
       max_iterations: 50,
       heartbeat_interval: 1800, # 30 minutes (1800s)
       mcp_endpoint: "http://localhost:7878",
@@ -181,6 +183,16 @@ module Pocketrb
 
       warn_env_deprecated("MCP_ENDPOINT", "mcp_endpoint") if ENV["MCP_ENDPOINT"]
       @data[:mcp_endpoint] = ENV["MCP_ENDPOINT"] if ENV["MCP_ENDPOINT"]
+
+      if ENV["POCKETRB_COMPACTION_MODEL"]
+        warn_env_deprecated("POCKETRB_COMPACTION_MODEL", "compaction_model")
+        @data[:compaction_model] = ENV["POCKETRB_COMPACTION_MODEL"]
+      end
+
+      if ENV["POCKETRB_COMPACTION_PRESSURE"]
+        warn_env_deprecated("POCKETRB_COMPACTION_PRESSURE", "compaction_pressure")
+        @data[:compaction_pressure] = ENV["POCKETRB_COMPACTION_PRESSURE"].to_f
+      end
 
       # Autonomous mode (for sandboxed environments)
       if %w[1 true].include?(ENV["POCKETRB_AUTONOMOUS"])

--- a/lib/pocketrb/providers/anthropic.rb
+++ b/lib/pocketrb/providers/anthropic.rb
@@ -26,6 +26,14 @@ module Pocketrb
         :anthropic
       end
 
+      # Get the context window size for a model
+      # @param model [String, nil] Model name (defaults to default_model)
+      # @return [Integer] Context window size in tokens
+      def context_window(model: nil)
+        model ||= default_model
+        MODELS.dig(model, :context) || super
+      end
+
       # Default model to use
       # @return [String]
       def default_model

--- a/lib/pocketrb/providers/base.rb
+++ b/lib/pocketrb/providers/base.rb
@@ -56,6 +56,13 @@ module Pocketrb
         raise NotImplementedError, "#{self.class}#name must be implemented"
       end
 
+      # Get the context window size for a model
+      # @param model [String, nil] Model name (defaults to default_model)
+      # @return [Integer] Context window size in tokens
+      def context_window(model: nil)
+        200_000
+      end
+
       # Check if provider supports a feature
       # @param feature [Symbol] :tools, :streaming, :thinking, :vision
       # @return [Boolean]

--- a/lib/pocketrb/session/session.rb
+++ b/lib/pocketrb/session/session.rb
@@ -134,6 +134,13 @@ module Pocketrb
         @mutex.synchronize { @messages.empty? }
       end
 
+      # Yield to block while holding the session mutex
+      # @yield Block to execute under the session lock
+      # @return [Object] Return value of the block
+      def with_lock(&)
+        @mutex.synchronize(&)
+      end
+
       # Set metadata value
       # @param key [String, Symbol] Metadata key
       # @param value [Object] Metadata value (any serializable object)

--- a/lib/pocketrb/version.rb
+++ b/lib/pocketrb/version.rb
@@ -3,5 +3,5 @@
 # Pocketrb: Ruby AI agent with multi-LLM support and advanced planning capabilities
 module Pocketrb
   # Gem version number
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/unit/pocketrb/agent/compaction_spec.rb
+++ b/spec/unit/pocketrb/agent/compaction_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe Pocketrb::Agent::Compaction do
   let(:compaction) { described_class.new(provider: provider) }
 
   before do
-    allow(provider).to receive(:default_model).and_return("test-model")
-    allow(provider).to receive(:context_window).and_return(200_000)
+    allow(provider).to receive_messages(default_model: "test-model", context_window: 200_000)
   end
 
   describe "#initialize" do

--- a/spec/unit/pocketrb/agent/compaction_spec.rb
+++ b/spec/unit/pocketrb/agent/compaction_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Pocketrb::Agent::Compaction do
 
   before do
     allow(provider).to receive(:default_model).and_return("test-model")
+    allow(provider).to receive(:context_window).and_return(200_000)
   end
 
   describe "#initialize" do
@@ -48,6 +49,30 @@ RSpec.describe Pocketrb::Agent::Compaction do
       custom = described_class.new(provider: provider, keep_recent: 5)
       expect(custom.keep_recent).to eq(5)
     end
+
+    it "uses provider context_window by default" do
+      expect(compaction.context_window).to eq(200_000)
+    end
+
+    it "accepts custom context_window" do
+      custom = described_class.new(provider: provider, context_window: 100_000)
+      expect(custom.context_window).to eq(100_000)
+    end
+
+    it "uses default context_pressure" do
+      expect(compaction.context_pressure).to eq(described_class::DEFAULT_CONTEXT_PRESSURE)
+    end
+
+    it "accepts custom context_pressure" do
+      custom = described_class.new(provider: provider, context_pressure: 0.5)
+      expect(custom.context_pressure).to eq(0.5)
+    end
+
+    it "stores on_compact callback" do
+      callback = proc { |_summary, _count| }
+      custom = described_class.new(provider: provider, on_compact: callback)
+      expect(custom.on_compact).to eq(callback)
+    end
   end
 
   describe "#needs_compaction?" do
@@ -77,6 +102,37 @@ RSpec.describe Pocketrb::Agent::Compaction do
     it "returns false when both thresholds not exceeded" do
       messages = Array.new(20) { Pocketrb::Providers::Message.user("Short") }
       expect(compaction.needs_compaction?(messages)).to be false
+    end
+
+    context "with pressure-based threshold" do
+      it "returns true when estimated tokens exceed context pressure" do
+        # Use a small context_window so pressure triggers easily
+        small_window = described_class.new(
+          provider: provider,
+          context_window: 1000,
+          context_pressure: 0.5,
+          # Set high fixed thresholds so only pressure triggers
+          message_threshold: 1000,
+          token_threshold: 1_000_000
+        )
+
+        # 20 messages * "x" * 200 chars = 4000 chars / 4 = 1000 tokens > 1000 * 0.5 = 500
+        messages = Array.new(20) { Pocketrb::Providers::Message.user("x" * 200) }
+        expect(small_window.needs_compaction?(messages)).to be true
+      end
+
+      it "returns false when below context pressure" do
+        small_window = described_class.new(
+          provider: provider,
+          context_window: 100_000,
+          context_pressure: 0.9,
+          message_threshold: 1000,
+          token_threshold: 1_000_000
+        )
+
+        messages = Array.new(20) { Pocketrb::Providers::Message.user("Short") }
+        expect(small_window.needs_compaction?(messages)).to be false
+      end
     end
   end
 
@@ -184,6 +240,57 @@ RSpec.describe Pocketrb::Agent::Compaction do
 
       expect(result.first.content).to include("Previous conversation")
     end
+
+    context "with on_compact callback" do
+      it "fires callback after successful compaction" do
+        callback_args = nil
+        callback = proc { |summary, count| callback_args = [summary, count] }
+        compaction_with_cb = described_class.new(provider: provider, on_compact: callback)
+
+        compaction_with_cb.compact(messages)
+
+        expect(callback_args).not_to be_nil
+        expect(callback_args[0]).to eq("Summary of conversation")
+        expect(callback_args[1]).to eq(35) # 50 - 15 keep_recent
+      end
+
+      it "does not fire callback when no compaction needed" do
+        called = false
+        callback = proc { |_summary, _count| called = true }
+        compaction_with_cb = described_class.new(provider: provider, on_compact: callback)
+
+        small = Array.new(10) { Pocketrb::Providers::Message.user("Test") }
+        compaction_with_cb.compact(small)
+
+        expect(called).to be false
+      end
+    end
+
+    context "with rolling summaries" do
+      it "passes prior summary to generate_summary when first message is a summary" do
+        summary_msg = Pocketrb::Providers::Message.user(
+          "[Previous conversation summary]\nOld summary content\n[End of summary - continuing conversation]"
+        )
+        msgs = [summary_msg] + Array.new(49) { |i| Pocketrb::Providers::Message.user("Message #{i}") }
+
+        compaction.compact(msgs)
+
+        expect(provider).to have_received(:chat) do |args|
+          user_msg = args[:messages].find { |m| m.role == "user" }
+          expect(user_msg.content).to include("Prior summary from earlier conversation:")
+          expect(user_msg.content).to include("Old summary content")
+        end
+      end
+
+      it "does not include prior summary when first message is not a summary" do
+        compaction.compact(messages)
+
+        expect(provider).to have_received(:chat) do |args|
+          user_msg = args[:messages].find { |m| m.role == "user" }
+          expect(user_msg.content).not_to include("Prior summary from earlier conversation:")
+        end
+      end
+    end
   end
 
   describe "#compact_session!" do
@@ -243,6 +350,133 @@ RSpec.describe Pocketrb::Agent::Compaction do
 
       expect(Pocketrb.logger).to have_received(:info).with(/Session compacted/)
     end
+
+    it "is thread-safe via mutex" do
+      50.times { session.add_message(role: "user", content: "Test") }
+
+      # Should not deadlock when called from multiple threads
+      threads = Array.new(3) do
+        Thread.new { compaction.compact_session!(session) }
+      end
+
+      expect { threads.each(&:join) }.not_to raise_error
+    end
+  end
+
+  describe "#schedule_compaction" do
+    let(:session) { Pocketrb::Session::Session.new(key: "test") }
+
+    before do
+      response = instance_double(
+        Pocketrb::Providers::LLMResponse,
+        content: "Summary"
+      )
+      allow(provider).to receive(:chat).and_return(response)
+      allow(Pocketrb.logger).to receive(:info)
+    end
+
+    it "returns nil when compaction not needed" do
+      10.times { session.add_message(role: "user", content: "Test") }
+
+      result = compaction.schedule_compaction(session)
+
+      expect(result).to be_nil
+    end
+
+    it "returns a thread when compaction is scheduled" do
+      50.times { session.add_message(role: "user", content: "Test") }
+
+      thread = compaction.schedule_compaction(session)
+
+      expect(thread).to be_a(Thread)
+      thread.join
+    end
+
+    it "compacts session in background" do
+      50.times { session.add_message(role: "user", content: "Test") }
+
+      thread = compaction.schedule_compaction(session)
+      thread.join
+
+      expect(session.message_count).to be < 50
+    end
+
+    it "returns nil if already compacting" do
+      50.times { session.add_message(role: "user", content: "Test") }
+
+      # Simulate slow compaction
+      allow(provider).to receive(:chat) do
+        sleep 0.1
+        instance_double(Pocketrb::Providers::LLMResponse, content: "Summary")
+      end
+
+      first_thread = compaction.schedule_compaction(session)
+      second_result = compaction.schedule_compaction(session)
+
+      expect(second_result).to be_nil
+
+      first_thread.join
+    end
+
+    it "sets compacting? to true during compaction" do
+      50.times { session.add_message(role: "user", content: "Test") }
+
+      allow(provider).to receive(:chat) do
+        sleep 0.1
+        instance_double(Pocketrb::Providers::LLMResponse, content: "Summary")
+      end
+
+      thread = compaction.schedule_compaction(session)
+      expect(compaction.compacting?).to be true
+
+      thread.join
+      expect(compaction.compacting?).to be false
+    end
+  end
+
+  describe "#wait_for_compaction" do
+    let(:session) { Pocketrb::Session::Session.new(key: "test") }
+
+    before do
+      response = instance_double(
+        Pocketrb::Providers::LLMResponse,
+        content: "Summary"
+      )
+      allow(provider).to receive(:chat).and_return(response)
+      allow(Pocketrb.logger).to receive(:info)
+    end
+
+    it "returns true when no compaction is running" do
+      expect(compaction.wait_for_compaction).to be true
+    end
+
+    it "waits for background compaction to finish" do
+      50.times { session.add_message(role: "user", content: "Test") }
+
+      compaction.schedule_compaction(session)
+      result = compaction.wait_for_compaction
+
+      expect(result).to be true
+      expect(compaction.compacting?).to be false
+    end
+
+    it "respects timeout" do
+      50.times { session.add_message(role: "user", content: "Test") }
+
+      allow(provider).to receive(:chat) do
+        sleep 5
+        instance_double(Pocketrb::Providers::LLMResponse, content: "Summary")
+      end
+
+      thread = compaction.schedule_compaction(session)
+      result = compaction.wait_for_compaction(timeout: 0.01)
+
+      expect(result).to be false
+
+      # Clean up
+      thread.kill
+      thread.join
+    end
   end
 
   describe "private methods" do
@@ -285,6 +519,28 @@ RSpec.describe Pocketrb::Agent::Compaction do
         expect(message.content).to include("[Previous conversation summary]")
         expect(message.content).to include("Test summary")
         expect(message.content).to include("[End of summary")
+      end
+    end
+
+    describe "#extract_prior_summary" do
+      it "returns nil for empty messages" do
+        result = compaction.send(:extract_prior_summary, [])
+        expect(result).to be_nil
+      end
+
+      it "returns nil when first message is not a summary" do
+        messages = [Pocketrb::Providers::Message.user("Regular message")]
+        result = compaction.send(:extract_prior_summary, messages)
+        expect(result).to be_nil
+      end
+
+      it "extracts summary text from a summary message" do
+        summary_msg = Pocketrb::Providers::Message.user(
+          "[Previous conversation summary]\nThe user discussed topic X\n[End of summary - continuing conversation]"
+        )
+        messages = [summary_msg]
+        result = compaction.send(:extract_prior_summary, messages)
+        expect(result).to eq("The user discussed topic X")
       end
     end
 

--- a/spec/unit/pocketrb/agent/compaction_spec.rb
+++ b/spec/unit/pocketrb/agent/compaction_spec.rb
@@ -72,6 +72,26 @@ RSpec.describe Pocketrb::Agent::Compaction do
       custom = described_class.new(provider: provider, on_compact: callback)
       expect(custom.on_compact).to eq(callback)
     end
+
+    it "raises ArgumentError for invalid context_window" do
+      expect { described_class.new(provider: provider, context_window: -1) }
+        .to raise_error(ArgumentError, /context_window must be a positive number/)
+    end
+
+    it "raises ArgumentError for zero context_window" do
+      expect { described_class.new(provider: provider, context_window: 0) }
+        .to raise_error(ArgumentError, /context_window must be a positive number/)
+    end
+
+    it "raises ArgumentError for context_pressure above 1.0" do
+      expect { described_class.new(provider: provider, context_pressure: 1.5) }
+        .to raise_error(ArgumentError, /context_pressure must be between 0.0 and 1.0/)
+    end
+
+    it "raises ArgumentError for negative context_pressure" do
+      expect { described_class.new(provider: provider, context_pressure: -0.1) }
+        .to raise_error(ArgumentError, /context_pressure must be between 0.0 and 1.0/)
+    end
   end
 
   describe "#needs_compaction?" do
@@ -540,6 +560,14 @@ RSpec.describe Pocketrb::Agent::Compaction do
         messages = [summary_msg]
         result = compaction.send(:extract_prior_summary, messages)
         expect(result).to eq("The user discussed topic X")
+      end
+
+      it "returns nil when marker appears mid-content (not at start)" do
+        msg = Pocketrb::Providers::Message.user(
+          "Some text before [Previous conversation summary]\nFake summary\n[End of summary - continuing conversation]"
+        )
+        result = compaction.send(:extract_prior_summary, [msg])
+        expect(result).to be_nil
       end
     end
 

--- a/spec/unit/pocketrb/agent/compaction_tool_mismatch_spec.rb
+++ b/spec/unit/pocketrb/agent/compaction_tool_mismatch_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Pocketrb::Agent::Compaction do
     )
     allow(provider).to receive_messages(
       default_model: "test-model",
+      context_window: 200_000,
       chat: response
     )
     allow(Pocketrb.logger).to receive(:info)


### PR DESCRIPTION
## Summary

- **Rolling summaries**: When re-compacting, the prior summary is passed as context to the LLM so important information is preserved across compaction cycles instead of being discarded
- **Pressure-based thresholds**: Compaction triggers when estimated tokens exceed a configurable percentage (`context_pressure`, default 70%) of the model's context window, adapting to different model sizes
- **Background compaction**: `schedule_compaction()` runs compaction in a background thread with mutex-based thread safety; `compact_session!` remains available as a synchronous alternative; `wait_for_compaction()` supports clean shutdown
- **Compaction callbacks**: `on_compact` proc fires after successful compaction with the summary text and compacted message count
- **Separate compaction model**: Configurable via `compaction_model` config key or `POCKETRB_COMPACTION_MODEL` env var to use a cheaper/faster model for summaries
- **Provider `context_window`**: `Base#context_window` returns 200K default; `Anthropic` overrides using the `MODELS` hash

All changes are backward-compatible — existing defaults are preserved.

## Test plan

- [x] All 62 compaction specs pass (`bundle exec rspec spec/unit/pocketrb/agent/compaction_spec.rb`)
- [x] All 105 provider specs pass (no regressions)
- [ ] Manual test: start CLI chat, send 50+ messages, verify compaction triggers with rolling summary
- [ ] Verify background compaction doesn't cause race conditions with concurrent messages