### PR TITLE
Enable lockFileMaintenance in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,5 +36,8 @@
   "labels": [
     "dependencies"
   ],
-  "minimumReleaseAge": "7 days"
+  "minimumReleaseAge": "7 days",
+  "lockFileMaintenance": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
This ensures Renovate periodically updates lockfile-only dependencies (transitive deps and those without version pins) that would otherwise never get updated.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->

Fixes #<!-- issue number -->

## Changes Made

<!-- List the specific changes made in this PR -->

-
-
-

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Existing tests pass (`bundle exec rspec`)
- [ ] Added new tests for new functionality
- [ ] Manual testing performed
- [ ] Tested with multiple LLM providers (if applicable)

**Test environment:**
- Ruby version:
- OS:
- Provider(s) tested:

## Documentation

- [ ] Updated README.md (if applicable)
- [ ] Updated CHANGELOG.md
- [ ] Added/updated code comments
- [ ] Added YARD documentation for public methods

## Code Quality

- [ ] Code follows the project's style guidelines
- [ ] `bundle exec rubocop` passes
- [ ] `bundle exec yard-lint lib/**/*.rb` passes
- [ ] No new warnings introduced

## Checklist

- [ ] My code follows the contribution guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information that reviewers should know -->
