### PR TITLE
Lower setup-ruby age gate to 5 days and schedule lock file maintenanc…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,13 @@
       ],
       "groupName": "ruby setup",
       "internalChecksFilter": "strict"
+    },
+    {
+      "description": "Let setup-ruby pass age gate before ruby so it is ready when the group PR is created",
+      "matchPackageNames": [
+        "ruby/setup-ruby"
+      ],
+      "minimumReleaseAge": "5 days"
     }
   ],
   "labels": [
@@ -39,6 +46,9 @@
   ],
   "minimumReleaseAge": "7 days",
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "schedule": [
+      "before 4am on the first day of the month"
+    ]
   }
 }


### PR DESCRIPTION
…e monthly

- Add a 5-day minimumReleaseAge for setup-ruby so its update clears the age gate before ruby's 7-day gate opens, ensuring both land in the same grouped PR.
- Schedule lock file maintenance to run monthly instead of weekly, so transitive dependency updates respect the 7-day age gate in practice.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/improvement

## Related Issue

<!-- Link to the issue this PR addresses, if applicable -->

Fixes #<!-- issue number -->

## Changes Made

<!-- List the specific changes made in this PR -->

-
-
-

## Testing

<!-- Describe the tests you ran to verify your changes -->

- [ ] Existing tests pass (`bundle exec rspec`)
- [ ] Added new tests for new functionality
- [ ] Manual testing performed
- [ ] Tested with multiple LLM providers (if applicable)

**Test environment:**
- Ruby version:
- OS:
- Provider(s) tested:

## Documentation

- [ ] Updated README.md (if applicable)
- [ ] Updated CHANGELOG.md
- [ ] Added/updated code comments
- [ ] Added YARD documentation for public methods

## Code Quality

- [ ] Code follows the project's style guidelines
- [ ] `bundle exec rubocop` passes
- [ ] `bundle exec yard-lint lib/**/*.rb` passes
- [ ] No new warnings introduced

## Checklist

- [ ] My code follows the contribution guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] New and existing tests pass locally
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information that reviewers should know -->
