### PR TITLE
Enhancement: Add Ruby warning category opt-in to test helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Enhancement: Add Ruby warning category opt-in to test helpers
+
 ## [0.2.0] - 2026-03-30
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :development, :test do
   gem "rspec", "~> 3.12"
   gem "simplecov", "~> 0.22", require: false
   gem "vcr", "~> 6.2"
+  gem "warning", "~> 1.4"
   gem "webmock", "~> 3.18"
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,26 @@
 # frozen_string_literal: true
 
+Warning[:performance] = true if RUBY_VERSION >= '3.3'
+Warning[:deprecated] = true
+$VERBOSE = true
+
+if Warning.respond_to?(:categories)
+  (Warning.categories - %i[deprecated experimental]).each { |cat| Warning[cat] = true }
+end
+
+require 'warning'
+
+Warning.process do |warning|
+  next unless warning.include?(Dir.pwd)
+  next if warning.include?('_spec')
+  next if warning.include?('previous definition of')
+  next if warning.include?('method redefined')
+  next if warning.include?('vendor/')
+  next if warning.include?('bundle/')
+  next if warning.include?('.bundle/')
+  raise "Warning in your code: #{warning}"
+end
+
 require "simplecov"
 SimpleCov.start do
   add_filter "/spec/"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,9 +8,6 @@ if Warning.respond_to?(:categories)
   (Warning.categories - %i[experimental]).each do |cat|
     Warning[cat] = true
   end
-else
-  Warning[:deprecated] = true
-  Warning[:performance] = true if RUBY_VERSION >= '3.3'
 end
 
 Warning.process do |warning|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
 
-Warning[:performance] = true if RUBY_VERSION >= '3.3'
-Warning[:deprecated] = true
+require 'warning'
+
 $VERBOSE = true
 
 if Warning.respond_to?(:categories)
   (Warning.categories - %i[experimental]).each do |cat|
     Warning[cat] = true
   end
+else
+  Warning[:deprecated] = true
+  Warning[:performance] = true if RUBY_VERSION >= '3.3'
 end
-
-require 'warning'
 
 Warning.process do |warning|
   next unless warning.include?(Dir.pwd)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,9 @@ Warning[:deprecated] = true
 $VERBOSE = true
 
 if Warning.respond_to?(:categories)
-  (Warning.categories - %i[experimental]).each { |cat| Warning[cat] = true }
+  (Warning.categories - %i[experimental]).each do |cat|
+    Warning[cat] = true
+  end
 end
 
 require 'warning'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'warning'
+require "warning"
 
 $VERBOSE = true
 
@@ -12,10 +12,11 @@ end
 
 Warning.process do |warning|
   next unless warning.include?(Dir.pwd)
-  next if warning.include?('_spec')
-  next if warning.include?('vendor/')
-  next if warning.include?('bundle/')
-  next if warning.include?('.bundle/')
+  next if warning.include?("_spec")
+  next if warning.include?("vendor/")
+  next if warning.include?("bundle/")
+  next if warning.include?(".bundle/")
+
   raise "Warning in your code: #{warning}"
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,8 +13,6 @@ end
 Warning.process do |warning|
   next unless warning.include?(Dir.pwd)
   next if warning.include?('_spec')
-  next if warning.include?('previous definition of')
-  next if warning.include?('method redefined')
   next if warning.include?('vendor/')
   next if warning.include?('bundle/')
   next if warning.include?('.bundle/')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ Warning[:deprecated] = true
 $VERBOSE = true
 
 if Warning.respond_to?(:categories)
-  (Warning.categories - %i[deprecated experimental]).each { |cat| Warning[cat] = true }
+  (Warning.categories - %i[experimental]).each { |cat| Warning[cat] = true }
 end
 
 require 'warning'


### PR DESCRIPTION
## Summary

- Adds `gem 'warning'` (~> 1.4) to the `:development, :test` group in `Gemfile`
- Inserts Ruby warning configuration block at the top of `spec/spec_helper.rb` (after frozen string literal comment) that enables deprecated/performance warning categories, opts in to all non-experimental categories on Ruby 3.3+, and raises on any warnings originating from project code
- Updates `CHANGELOG.md` with the enhancement entry under `[Unreleased]`

## Test plan

- [ ] `bundle install` completes successfully with the `warning` gem present
- [ ] Running the test suite produces no new failures from the warning setup
- [ ] Warnings in project code (excluding specs, vendor, bundle paths) are raised as errors