### PR TITLE
fix: replace regex matchers with string include matchers in write_file_spec

### DIFF
--- a/spec/unit/pocketrb/tools/write_file_spec.rb
+++ b/spec/unit/pocketrb/tools/write_file_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe Pocketrb::Tools::WriteFile do
       it "reports line count and byte size" do
         result = tool.execute(path: "test.txt", content: "Line 1\nLine 2\nLine 3")
 
-        expect(result).to include('Wrote 3 lines')
-        expect(result).to include('20 bytes')
+        expect(result).to include("Wrote 3 lines")
+        expect(result).to include("20 bytes")
       end
     end
 

--- a/spec/unit/pocketrb/tools/write_file_spec.rb
+++ b/spec/unit/pocketrb/tools/write_file_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe Pocketrb::Tools::WriteFile do
       it "reports line count and byte size" do
         result = tool.execute(path: "test.txt", content: "Line 1\nLine 2\nLine 3")
 
-        expect(result).to match(/Wrote 3 lines/)
-        expect(result).to match(/20 bytes/)
+        expect(result).to include('Wrote 3 lines')
+        expect(result).to include('20 bytes')
       end
     end
 


### PR DESCRIPTION
## Summary

- Fixes 2 `RSpec/MatchWithSimpleRegex` RuboCop offenses in `spec/unit/pocketrb/tools/write_file_spec.rb`
- Replaces `match(/Wrote 3 lines/)` and `match(/20 bytes/)` with `include('Wrote 3 lines')` and `include('20 bytes')` since the regexes are plain string literals with no special regex syntax

## Test plan

- [ ] RuboCop CI job passes
- [ ] Specs CI job continues to pass