### PR TITLE
Fix invalid Renovate matchDepNames pattern

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
     {
       "minimumReleaseAge": "7 days",
       "matchDepNames": [
-        "/*/"
+        "*"
       ]
     },
     {


### PR DESCRIPTION
Closes #48

## What

Fixes the Renovate configuration error that is currently blocking all Renovate PRs in this repo (see the open "Action Required: Fix Renovate Configuration" issue).

## The problem

`packageRules` used `"matchDepNames": ["/*/"]`. Wrapping a value in slashes (`/.../`) tells Renovate to treat it as a **regex**, and `*` on its own is an invalid regex (quantifier with nothing to repeat), so config parsing fails:

```
Failed to parse regex pattern for packageRules[0].matchDepNames: /*/
```

When parsing fails, Renovate halts all PRs as a precaution.

## The fix

Replace `"/*/"` with `"*"` — a plain glob that matches all dependency names, preserving the original intent (apply the 7-day `minimumReleaseAge` to everything).

> Note: this rule is actually redundant with the top-level `"minimumReleaseAge": "7 days"`, so it could alternatively be removed entirely. Kept as a minimal one-character fix for an easy review.