### PR TITLE
Enable new yard-lint 1.10 documentation linters

### DIFF
--- a/.yard-lint.yml
+++ b/.yard-lint.yml
@@ -62,6 +62,26 @@ Documentation/BlankLineBeforeDefinition:
     SingleBlankLine: true
     OrphanedDocs: true
 
+Documentation/DuplicateNamespaceComment:
+  Description: Detects namespaces documented with a YARD comment in more than one file.
+  Enabled: true
+  Severity: error
+
+Documentation/UnderfilledLines:
+  Description: Detects documentation prose that wraps too early and wastes horizontal space.
+  Enabled: true
+  Severity: error
+  # Aligned with RuboCop's Layout/LineLength so documentation prose wraps to the same
+  # width as code.
+  MaxLength: 120
+
+Documentation/LineLength:
+  Description: Detects documentation lines that exceed the maximum length.
+  Enabled: true
+  Severity: error
+  # Aligned with RuboCop's Layout/LineLength.
+  MaxLength: 120
+
 # Tags validators
 Tags/Order:
   Description: Enforces consistent ordering of YARD tags.
@@ -142,7 +162,7 @@ Tags/OptionTags:
 Tags/ExampleSyntax:
   Description: Validates Ruby syntax in @example tags.
   Enabled: true
-  Severity: warning
+  Severity: error
 
 Tags/RedundantParamDescription:
   Description: Detects meaningless parameter descriptions that add no value.

--- a/lib/pocketrb/agent/compaction.rb
+++ b/lib/pocketrb/agent/compaction.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# Pocketrb: Ruby AI agent with multi-LLM support and advanced planning capabilities
 module Pocketrb
   module Agent
     # Context compaction to summarize long conversations and save tokens
@@ -31,11 +30,15 @@ module Pocketrb
       # Initialize a new compaction instance
       # @param provider [Object] LLM provider instance for generating summaries
       # @param model [String, nil] Model name to use for summarization (defaults to provider default)
-      # @param message_threshold [Integer, nil] Maximum messages before compaction (defaults to DEFAULT_MESSAGE_THRESHOLD)
-      # @param token_threshold [Integer, nil] Maximum estimated tokens before compaction (defaults to DEFAULT_TOKEN_THRESHOLD)
-      # @param keep_recent [Integer, nil] Number of recent messages to keep uncompacted (defaults to DEFAULT_KEEP_RECENT)
+      # @param message_threshold [Integer, nil] Maximum messages before compaction (defaults to
+      #   DEFAULT_MESSAGE_THRESHOLD)
+      # @param token_threshold [Integer, nil] Maximum estimated tokens before compaction (defaults to
+      #   DEFAULT_TOKEN_THRESHOLD)
+      # @param keep_recent [Integer, nil] Number of recent messages to keep uncompacted (defaults to
+      #   DEFAULT_KEEP_RECENT)
       # @param context_window [Integer, nil] Model context window size in tokens (defaults to provider value)
-      # @param context_pressure [Float, nil] Fraction of context window that triggers compaction (defaults to DEFAULT_CONTEXT_PRESSURE)
+      # @param context_pressure [Float, nil] Fraction of context window that triggers compaction (defaults to
+      #   DEFAULT_CONTEXT_PRESSURE)
       # @param on_compact [Proc, nil] Callback called after compaction with (summary, compacted_count)
       def initialize(
         provider:,
@@ -239,9 +242,8 @@ module Pocketrb
         true
       end
 
-      # Adjust split point to keep tool_use/tool_result pairs together
-      # If a tool_result is in the kept messages, ensure its corresponding
-      # assistant message with tool_calls is also kept
+      # Adjust split point to keep tool_use/tool_result pairs together. If a tool_result is in the kept messages, ensure
+      # its corresponding assistant message with tool_calls is also kept
       # @param messages [Array<Message>] full conversation history including tool use/result pairs
       # @param split_point [Integer] Initial split point
       # @return [Integer] Adjusted split point

--- a/lib/pocketrb/bus/events.rb
+++ b/lib/pocketrb/bus/events.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# Pocketrb: Ruby AI agent with multi-LLM support and advanced planning capabilities
 module Pocketrb
   # Bus module provides the message bus architecture for multi-channel communication
   module Bus

--- a/lib/pocketrb/channels/base.rb
+++ b/lib/pocketrb/channels/base.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# Pocketrb: Ruby AI agent with multi-LLM support and advanced planning capabilities
 module Pocketrb
   module Channels
     # Base class for channel adapters

--- a/lib/pocketrb/channels/telegram.rb
+++ b/lib/pocketrb/channels/telegram.rb
@@ -4,8 +4,7 @@ require "telegram/bot"
 
 module Pocketrb
   module Channels
-    # Telegram channel using long polling
-    # Simple and reliable - no webhook/public IP needed
+    # Telegram channel using long polling. Simple and reliable - no webhook/public IP needed
     class Telegram < Base
       # Markdown to HTML conversion patterns for Telegram formatting
       MARKDOWN_TO_HTML = {

--- a/lib/pocketrb/channels/whatsapp.rb
+++ b/lib/pocketrb/channels/whatsapp.rb
@@ -5,8 +5,7 @@ require "socket"
 
 module Pocketrb
   module Channels
-    # WhatsApp channel via Node.js bridge WebSocket
-    # Connects to a whatsapp-web.js bridge running on localhost
+    # WhatsApp channel via Node.js bridge WebSocket. Connects to a whatsapp-web.js bridge running on localhost
     #
     # Bridge Protocol:
     # - Receive: {type: "message", sender: "...", content: "...", timestamp: ..., isGroup: bool}

--- a/lib/pocketrb/cli.rb
+++ b/lib/pocketrb/cli.rb
@@ -2,7 +2,6 @@
 
 require "thor"
 
-# Main namespace for Pocketrb gem
 module Pocketrb
   # Command-line interface
   class CLI < Thor

--- a/lib/pocketrb/mcp/client.rb
+++ b/lib/pocketrb/mcp/client.rb
@@ -4,12 +4,10 @@ require "faraday"
 require "json"
 require "securerandom"
 
-# Pocketrb: Ruby AI agent with multi-LLM support and advanced planning capabilities
 module Pocketrb
   # Model Context Protocol (MCP) integration for memory and tool servers
   module MCP
-    # MCP client for connecting to MCP HTTP Bridge
-    # Implements JSON-RPC 2.0 protocol for MCP communication
+    # MCP client for connecting to MCP HTTP Bridge. Implements JSON-RPC 2.0 protocol for MCP communication
     class Client
       # Default MCP server endpoint URL
       DEFAULT_ENDPOINT = "http://localhost:7878"

--- a/lib/pocketrb/media/processor.rb
+++ b/lib/pocketrb/media/processor.rb
@@ -33,7 +33,8 @@ module Pocketrb
       attr_reader :cache_dir
 
       # Initialize media processor
-      # @param cache_dir [String, Pathname, nil] Directory path for caching downloaded media (defaults to system temp dir)
+      # @param cache_dir [String, Pathname, nil] Directory path for caching downloaded media (defaults to system temp
+      #   dir)
       def initialize(cache_dir: nil)
         @cache_dir = cache_dir || default_cache_dir
         ensure_cache_dir!

--- a/lib/pocketrb/memory.rb
+++ b/lib/pocketrb/memory.rb
@@ -4,8 +4,7 @@ require "json"
 require "fileutils"
 
 module Pocketrb
-  # Simple memory system for facts and recent events
-  # Inspired by nanobot - no vector DB, just JSON + keyword matching
+  # Simple memory system for facts and recent events. Inspired by nanobot - no vector DB, just JSON + keyword matching
   class Memory
     # Maximum number of recent events to keep
     MAX_RECENT = 50

--- a/lib/pocketrb/providers/anthropic.rb
+++ b/lib/pocketrb/providers/anthropic.rb
@@ -5,8 +5,7 @@ require "json"
 
 module Pocketrb
   module Providers
-    # Direct Anthropic Claude API provider
-    # Supports extended thinking and all Claude-specific features
+    # Direct Anthropic Claude API provider. Supports extended thinking and all Claude-specific features
     class Anthropic < Base
       # Anthropic API base URL
       API_URL = "https://api.anthropic.com/v1"

--- a/lib/pocketrb/providers/claude_cli.rb
+++ b/lib/pocketrb/providers/claude_cli.rb
@@ -3,7 +3,6 @@
 require "json"
 require "open3"
 
-# Pocketrb: Ruby AI agent with multi-LLM support and advanced planning capabilities
 module Pocketrb
   # LLM provider implementations
   module Providers

--- a/lib/pocketrb/providers/claude_max_proxy.rb
+++ b/lib/pocketrb/providers/claude_max_proxy.rb
@@ -6,10 +6,9 @@ require "uri"
 
 module Pocketrb
   module Providers
-    # Claude Max API Proxy provider
-    # Uses the claude-max-api-proxy which provides OpenAI-compatible API
-    # Install: npm install -g claude-max-api-proxy
-    # Start: claude-max-api (runs on localhost:3456)
+    # Claude Max API Proxy provider. Uses the claude-max-api-proxy which provides OpenAI-compatible API
+    # - Install: npm install -g claude-max-api-proxy
+    # - Start: claude-max-api (runs on localhost:3456)
     class ClaudeMaxProxy < Base
       # Available model aliases mapped to full model names
       MODELS = {

--- a/lib/pocketrb/providers/openrouter.rb
+++ b/lib/pocketrb/providers/openrouter.rb
@@ -3,12 +3,9 @@
 require "faraday"
 require "json"
 
-# Pocketrb: Ruby AI agent with multi-LLM support and advanced planning capabilities
 module Pocketrb
-  # LLM provider implementations
   module Providers
-    # OpenRouter API provider for multi-model access
-    # Supports Claude, GPT-4, Llama, and many other models
+    # OpenRouter API provider for multi-model access. Supports Claude, GPT-4, Llama, and many other models
     class OpenRouter < Base
       # OpenRouter API base URL
       API_URL = "https://openrouter.ai/api/v1"

--- a/lib/pocketrb/providers/ruby_llm_provider.rb
+++ b/lib/pocketrb/providers/ruby_llm_provider.rb
@@ -1,11 +1,8 @@
 # frozen_string_literal: true
 
-# Pocketrb: Ruby AI agent with multi-LLM support and advanced planning capabilities
 module Pocketrb
-  # LLM provider implementations
   module Providers
-    # Provider using the RubyLLM gem for multi-model support
-    # This is an alternative to direct API calls
+    # Provider using the RubyLLM gem for multi-model support. This is an alternative to direct API calls
     class RubyLLMProvider < Base
       # Provider name
       # @return [Symbol]
@@ -54,7 +51,6 @@ module Pocketrb
         parse_ruby_llm_response(response, model)
       end
 
-      # Send streaming chat completion request
       # Send streaming chat completion request
       # @param messages [Array<Message>] Conversation messages
       # @param tools [Array<Hash>, nil] Tool definitions

--- a/lib/pocketrb/tools/exec.rb
+++ b/lib/pocketrb/tools/exec.rb
@@ -3,7 +3,6 @@
 require "open3"
 require "timeout"
 
-# Pocketrb: Ruby AI agent with multi-LLM support and advanced planning capabilities
 module Pocketrb
   # Tool implementations for agent capabilities
   module Tools

--- a/lib/pocketrb/tools/memory.rb
+++ b/lib/pocketrb/tools/memory.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Pocketrb: Ruby AI agent with multi-LLM support and advanced planning capabilities
 module Pocketrb
-  # Tool implementations for agent capabilities
   module Tools
     # Simple memory tool - store and recall facts
     class Memory < Base

--- a/lib/pocketrb/tools/para_memory.rb
+++ b/lib/pocketrb/tools/para_memory.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-# Pocketrb: Ruby AI agent with multi-LLM support and advanced planning capabilities
 module Pocketrb
-  # Tool implementations for agent capabilities
   module Tools
     # PARA-based memory tool for structured knowledge management
     class ParaMemory < Base
@@ -89,7 +87,8 @@ module Pocketrb
       end
 
       # Execute memory action
-      # @param action [String] Action to perform (store, search, entity_info, create_entity, list_entities, context, preferences, learn_preference)
+      # @param action [String] Action to perform (store, search, entity_info, create_entity, list_entities, context,
+      #   preferences, learn_preference)
       # @option args [String] :content Fact content to store
       # @option args [String] :category Fact category (relationship, milestone, status, preference, context)
       # @option args [String] :entity_type PARA entity type (projects, areas, resources, archives)

--- a/lib/pocketrb/version.rb
+++ b/lib/pocketrb/version.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# Pocketrb: Ruby AI agent with multi-LLM support and advanced planning capabilities
 module Pocketrb
   # Gem version number
   VERSION = "0.2.0"


### PR DESCRIPTION
Updates yard-lint to 1.10.1 and enables the new documentation linters (`DuplicateNamespaceComment`, `UnderfilledLines` as errors; `ExampleSyntax` to error), with `MaxLength` aligned to this project's RuboCop `Layout/LineLength`. Fixes every offense they surface. `bundle exec yard-lint lib/` reports `No offenses found`.