### PR TITLE
Backfill missing gemspec metadata

### DIFF
--- a/pocketrb.gemspec
+++ b/pocketrb.gemspec
@@ -52,6 +52,7 @@ Gem::Specification.new do |spec|
     "changelog_uri" => "https://github.com/mensfeld/pocketrb/blob/master/CHANGELOG.md",
     "homepage_uri" => "https://github.com/mensfeld/pocketrb",
     "source_code_uri" => "https://github.com/mensfeld/pocketrb/tree/master",
+    "documentation_uri" => "https://github.com/mensfeld/pocketrb",
     "rubygems_mfa_required" => "true"
   }
 end


### PR DESCRIPTION
Adds the `metadata` keys this gem was missing relative to the rest of the fleet (per the gemspec audit): **documentation_uri **

- URIs point at the standard GitHub locations (`/issues` for bug tracker, repo URL for docs/homepage), matching the repo's existing quote/interpolation style.
- Improves the rubygems.org sidebar links.

Gemspec loads cleanly (`Gem::Specification.load`); no other changes.